### PR TITLE
Complete run registry: add delete, compare, filtered list

### DIFF
--- a/DOCS_INDEX.md
+++ b/DOCS_INDEX.md
@@ -1,0 +1,75 @@
+# 📚 Documentation Index
+
+This directory contains guides to help with implementing the Run Registry feature for the Project Paradise Backtester.
+
+## Documents
+
+### 1. **PATRICK_START_HERE.md** ⭐ Start Here!
+Quick answer to Patrick's immediate questions:
+- Do I need to make a new folder?
+- Is there baseline in place?
+- Where should I start?
+
+**Read this first** for a quick orientation (5 min read).
+
+### 2. **RUN_REGISTRY_GUIDE.md** 📖 Complete Guide
+Comprehensive implementation guide with:
+- Current state analysis (what exists, what's missing)
+- Recommended architecture and file structure
+- Complete code examples for all components
+- Usage examples and patterns
+- Integration strategies
+- Development workflow and time estimates
+
+**Read this** when you're ready to start implementing (20 min read).
+
+## Quick Summary
+
+**Question:** Where do I start with the run registry feature?
+
+**Answer:** 
+1. Create new folder: `vectorbt/portfolio/registry/`
+2. No baseline exists yet - this is a new feature
+3. You CAN leverage existing infrastructure (Portfolio serialization, Records)
+4. Estimated implementation: 6-8 hours
+
+## Files You'll Create
+
+```
+vectorbt/portfolio/registry/
+├── __init__.py              # Package exports
+├── run.py                   # RunRecord dataclass
+├── registry.py              # RunRegistry main interface
+└── stores/
+    ├── __init__.py
+    └── file_store.py        # File-based storage backend
+```
+
+## What is a Run Registry?
+
+A **Run Registry** is a system that tracks and manages backtest runs, allowing users to:
+- 💾 Save backtest results with metadata (strategy name, parameters, tags)
+- 📋 List and filter past runs
+- 🔍 Compare multiple runs side-by-side
+- 📊 Find best-performing configurations
+- 🔄 Reload old portfolios for analysis
+
+Think of it as a "database" or "history" for all your backtests, instead of running them and losing the results when your Python session ends.
+
+## Why This Matters
+
+As Lev said:
+> "Run registry would be awesome to be honest, i think that's something that's really missing from many backtesters"
+
+Most backtesting tools let you run tests but don't provide a systematic way to track and compare results over time. This feature fills that gap!
+
+## Need Help?
+
+- Questions about the architecture? → See RUN_REGISTRY_GUIDE.md "Recommended Implementation Plan"
+- Not sure what exists already? → See RUN_REGISTRY_GUIDE.md "Current State of the Repository"
+- Want to see usage examples? → See RUN_REGISTRY_GUIDE.md "Usage Examples"
+- Just want to get started? → Read PATRICK_START_HERE.md
+
+---
+
+Happy coding! 🚀

--- a/PATRICK_START_HERE.md
+++ b/PATRICK_START_HERE.md
@@ -1,0 +1,76 @@
+# Quick Answer for Patrick
+
+Hey Patrick! 👋
+
+## Your Questions Answered
+
+> "The directory has so much going on 😂 not really sure where to get started"
+
+I get it! The repo is a fork of vectorbt (a popular backtesting library), so there's a lot of code. But don't worry - for the run registry feature, you'll be working in a **specific area**.
+
+> "do i need to make a new folder to start working on this or is there already baseline in place?"
+
+**Answer: You need to make a NEW folder** ✅
+
+## Where to Start
+
+1. **Create this new folder:**
+   ```bash
+   mkdir -p vectorbt/portfolio/registry/stores
+   ```
+
+2. **Start with these files (in order):**
+   - `vectorbt/portfolio/registry/run.py` - Define what a "run" is
+   - `vectorbt/portfolio/registry/stores/file_store.py` - Save/load runs from disk
+   - `vectorbt/portfolio/registry/registry.py` - Main API users will use
+   - `vectorbt/portfolio/registry/__init__.py` - Package exports
+
+## What Already Exists (Good News!)
+
+The repo DOES have some baseline infrastructure you can use:
+
+✅ **Portfolio serialization** - Portfolios can already be saved/loaded (`portfolio.save()`, `Portfolio.load()`)
+✅ **Records system** - Framework for structured data (trades, orders)
+✅ **Stats calculation** - `.stats()` gives you all performance metrics
+
+## What's Missing (Your Task!)
+
+❌ No way to save MULTIPLE runs as a collection
+❌ No metadata tracking (strategy name, parameters, timestamp)
+❌ No ability to compare past runs
+❌ No "history" of backtests
+
+## Your Mission
+
+Build a **Run Registry** that lets users:
+- Save backtest runs with metadata (strategy name, params, tags)
+- List all past runs
+- Filter runs by strategy or tags
+- Load old runs to compare
+- Track best-performing configurations
+
+## Full Implementation Details
+
+See the complete guide in `RUN_REGISTRY_GUIDE.md` - it has:
+- Detailed file structure
+- Full code examples for each file
+- Usage examples
+- Integration patterns
+- 6-8 hour estimated implementation time
+
+## Quick Start Command
+
+```bash
+cd /path/to/project-paradise-backtester/vectorbt/portfolio
+mkdir -p registry/stores
+cd registry
+touch __init__.py run.py registry.py stores/__init__.py stores/file_store.py
+```
+
+Then start coding in `run.py`!
+
+---
+
+**Bottom line:** You're creating something NEW that doesn't exist yet. There's no baseline run registry, but there IS good infrastructure to build on. You'll live in `vectorbt/portfolio/registry/` and it should take about a day of focused work.
+
+Good luck! 🚀

--- a/RUN_REGISTRY_GUIDE.md
+++ b/RUN_REGISTRY_GUIDE.md
@@ -1,0 +1,629 @@
+# Run Registry Implementation Guide
+
+## Patrick's Question Answered
+
+> "The directory has so much going on 😂 not really sure where to get started. Do I need to make a new folder to start working on this or is there already baseline in place?"
+
+**TL;DR:** You'll need to create a **new module**, but you can leverage existing infrastructure. Start by creating `vectorbt/portfolio/registry/` - there's no baseline run registry yet, but the groundwork (serialization, records) is already there.
+
+---
+
+## 📋 Current State of the Repository
+
+### What EXISTS Already
+
+✅ **Serialization Infrastructure** (`vectorbt/utils/config.py`)
+- `Pickleable` mixin with `.save()` and `.load()` methods
+- Portfolio objects can already be saved/loaded individually
+- Uses pickle/dill for Python object persistence
+
+✅ **Portfolio Tracking** (`vectorbt/portfolio/`)
+- `Portfolio` class captures complete backtest state
+- `OrderRecords` - all orders with timestamps
+- `TradeRecords` - entry/exit data for each trade
+- `.stats()` method - comprehensive performance metrics
+
+✅ **Record Management** (`vectorbt/records/`)
+- `Records` base class for structured data arrays
+- `MappedArray` for efficient array operations
+- Decorators for field configuration
+
+### What's MISSING (Your Opportunity!)
+
+❌ **No Run Registry System**
+- No way to save multiple backtest runs as a collection
+- No metadata tracking (run name, parameters, timestamp)
+- No query/filter capabilities for past runs
+- No comparison tools between runs
+
+❌ **No Persistent History**
+- Runs only exist in memory during execution
+- No centralized storage for results
+- Can't retrieve old backtests for analysis
+
+---
+
+## 🎯 Recommended Implementation Plan
+
+### Phase 1: Core Registry Structure
+
+Create a new module: **`vectorbt/portfolio/registry/`**
+
+```
+vectorbt/portfolio/registry/
+├── __init__.py              # Public API exports
+├── run.py                   # RunRecord class (metadata + results)
+├── registry.py              # RunRegistry main interface
+├── store.py                 # Abstract base for storage backends
+└── stores/                  # Concrete implementations
+    ├── __init__.py
+    ├── file_store.py        # JSON/Pickle filesystem storage
+    └── sqlite_store.py      # SQLite for querying (optional Phase 2)
+```
+
+### Phase 2: Data Model (`run.py`)
+
+```python
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, Any, Optional, List
+import uuid
+
+@dataclass
+class RunRecord:
+    """Metadata for a single backtest run."""
+    
+    run_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+    strategy_name: str = ""
+    parameters: Dict[str, Any] = field(default_factory=dict)
+    
+    # Summary stats (avoid storing full Portfolio here)
+    total_return: float = 0.0
+    sharpe_ratio: float = 0.0
+    max_drawdown: float = 0.0
+    total_trades: int = 0
+    win_rate: float = 0.0
+    
+    # Reference to saved Portfolio (file path or key)
+    portfolio_path: Optional[str] = None
+    
+    # Optional metadata
+    tags: List[str] = field(default_factory=list)
+    notes: str = ""
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        return {
+            'run_id': self.run_id,
+            'timestamp': self.timestamp.isoformat(),
+            'strategy_name': self.strategy_name,
+            'parameters': self.parameters,
+            'stats': {
+                'total_return': self.total_return,
+                'sharpe_ratio': self.sharpe_ratio,
+                'max_drawdown': self.max_drawdown,
+                'total_trades': self.total_trades,
+                'win_rate': self.win_rate,
+            },
+            'portfolio_path': self.portfolio_path,
+            'tags': self.tags,
+            'notes': self.notes,
+        }
+    
+    @classmethod
+    def from_portfolio(cls, 
+                      pf, 
+                      strategy_name: str = "",
+                      parameters: Dict[str, Any] = None,
+                      tags: List[str] = None,
+                      notes: str = "") -> 'RunRecord':
+        """Create RunRecord from a Portfolio object."""
+        stats = pf.stats()
+        
+        return cls(
+            strategy_name=strategy_name,
+            parameters=parameters or {},
+            total_return=float(stats.get('Total Return [%]', 0)),
+            sharpe_ratio=float(stats.get('Sharpe Ratio', 0)),
+            max_drawdown=float(stats.get('Max Drawdown [%]', 0)),
+            total_trades=int(stats.get('Total Trades', 0)),
+            win_rate=float(stats.get('Win Rate [%]', 0)),
+            tags=tags or [],
+            notes=notes,
+        )
+```
+
+### Phase 3: Storage Backend (`stores/file_store.py`)
+
+```python
+import json
+import os
+from pathlib import Path
+from typing import List, Optional, Dict, Any
+from ..run import RunRecord
+from ..store import RunStore
+
+class FileStore(RunStore):
+    """File-based storage for run records."""
+    
+    def __init__(self, base_dir: str = "./backtest_runs"):
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.metadata_file = self.base_dir / "runs_metadata.json"
+        self.portfolios_dir = self.base_dir / "portfolios"
+        self.portfolios_dir.mkdir(exist_ok=True)
+        
+    def save_run(self, run: RunRecord, portfolio=None) -> str:
+        """Save a run record and optionally its portfolio."""
+        # Save portfolio if provided
+        if portfolio is not None:
+            portfolio_filename = f"{run.run_id}.pkl"
+            portfolio_path = self.portfolios_dir / portfolio_filename
+            portfolio.save(str(portfolio_path))
+            run.portfolio_path = str(portfolio_path)
+        
+        # Load existing metadata
+        runs = self._load_metadata()
+        
+        # Add new run
+        runs[run.run_id] = run.to_dict()
+        
+        # Save metadata
+        self._save_metadata(runs)
+        
+        return run.run_id
+    
+    def get_run(self, run_id: str) -> Optional[RunRecord]:
+        """Retrieve a run by ID."""
+        runs = self._load_metadata()
+        if run_id not in runs:
+            return None
+        return self._dict_to_record(runs[run_id])
+    
+    def list_runs(self, 
+                  strategy_name: Optional[str] = None,
+                  tags: Optional[List[str]] = None) -> List[RunRecord]:
+        """List all runs, optionally filtered."""
+        runs = self._load_metadata()
+        records = [self._dict_to_record(r) for r in runs.values()]
+        
+        # Filter by strategy
+        if strategy_name:
+            records = [r for r in records if r.strategy_name == strategy_name]
+        
+        # Filter by tags
+        if tags:
+            records = [r for r in records if any(tag in r.tags for tag in tags)]
+        
+        # Sort by timestamp (newest first)
+        records.sort(key=lambda r: r.timestamp, reverse=True)
+        
+        return records
+    
+    def load_portfolio(self, run_id: str):
+        """Load the portfolio for a run."""
+        run = self.get_run(run_id)
+        if run is None or run.portfolio_path is None:
+            return None
+        
+        # Use vectorbt's built-in load functionality
+        from vectorbt import Portfolio
+        return Portfolio.load(run.portfolio_path)
+    
+    def delete_run(self, run_id: str) -> bool:
+        """Delete a run and its portfolio."""
+        runs = self._load_metadata()
+        if run_id not in runs:
+            return False
+        
+        # Delete portfolio file
+        portfolio_path = runs[run_id].get('portfolio_path')
+        if portfolio_path and os.path.exists(portfolio_path):
+            os.remove(portfolio_path)
+        
+        # Remove from metadata
+        del runs[run_id]
+        self._save_metadata(runs)
+        
+        return True
+    
+    def _load_metadata(self) -> Dict[str, Any]:
+        """Load metadata from JSON file."""
+        if not self.metadata_file.exists():
+            return {}
+        with open(self.metadata_file, 'r') as f:
+            return json.load(f)
+    
+    def _save_metadata(self, runs: Dict[str, Any]):
+        """Save metadata to JSON file."""
+        with open(self.metadata_file, 'w') as f:
+            json.dump(runs, f, indent=2)
+    
+    @staticmethod
+    def _dict_to_record(data: Dict[str, Any]) -> RunRecord:
+        """Convert dict to RunRecord."""
+        from datetime import datetime
+        return RunRecord(
+            run_id=data['run_id'],
+            timestamp=datetime.fromisoformat(data['timestamp']),
+            strategy_name=data['strategy_name'],
+            parameters=data['parameters'],
+            total_return=data['stats']['total_return'],
+            sharpe_ratio=data['stats']['sharpe_ratio'],
+            max_drawdown=data['stats']['max_drawdown'],
+            total_trades=data['stats']['total_trades'],
+            win_rate=data['stats']['win_rate'],
+            portfolio_path=data.get('portfolio_path'),
+            tags=data.get('tags', []),
+            notes=data.get('notes', ''),
+        )
+```
+
+### Phase 4: Registry Interface (`registry.py`)
+
+```python
+from typing import List, Optional, Dict, Any
+from .run import RunRecord
+from .stores.file_store import FileStore
+
+class RunRegistry:
+    """Main interface for managing backtest runs."""
+    
+    def __init__(self, store=None):
+        self.store = store or FileStore()
+    
+    def save_run(self,
+                 portfolio,
+                 strategy_name: str,
+                 parameters: Dict[str, Any] = None,
+                 tags: List[str] = None,
+                 notes: str = "",
+                 save_portfolio: bool = True) -> str:
+        """
+        Save a backtest run to the registry.
+        
+        Args:
+            portfolio: The Portfolio object to save
+            strategy_name: Name of the strategy
+            parameters: Strategy parameters/config
+            tags: List of tags for filtering
+            notes: Optional notes about the run
+            save_portfolio: Whether to save full Portfolio (default True)
+            
+        Returns:
+            run_id: Unique ID for this run
+        """
+        # Create run record from portfolio
+        run = RunRecord.from_portfolio(
+            portfolio,
+            strategy_name=strategy_name,
+            parameters=parameters,
+            tags=tags,
+            notes=notes
+        )
+        
+        # Save to store
+        pf_to_save = portfolio if save_portfolio else None
+        return self.store.save_run(run, pf_to_save)
+    
+    def get_run(self, run_id: str) -> Optional[RunRecord]:
+        """Get metadata for a specific run."""
+        return self.store.get_run(run_id)
+    
+    def load_portfolio(self, run_id: str):
+        """Load the full Portfolio for a run."""
+        return self.store.load_portfolio(run_id)
+    
+    def list_runs(self,
+                  strategy_name: Optional[str] = None,
+                  tags: Optional[List[str]] = None) -> List[RunRecord]:
+        """
+        List runs, optionally filtered.
+        
+        Args:
+            strategy_name: Filter by strategy name
+            tags: Filter by tags (matches any)
+            
+        Returns:
+            List of RunRecords sorted by timestamp (newest first)
+        """
+        return self.store.list_runs(strategy_name, tags)
+    
+    def compare_runs(self, run_ids: List[str]) -> Dict[str, Any]:
+        """
+        Compare multiple runs side-by-side.
+        
+        Returns:
+            Dict with comparison data suitable for DataFrame/table
+        """
+        runs = [self.get_run(rid) for rid in run_ids]
+        runs = [r for r in runs if r is not None]
+        
+        comparison = {
+            'run_id': [r.run_id for r in runs],
+            'strategy': [r.strategy_name for r in runs],
+            'timestamp': [r.timestamp for r in runs],
+            'total_return': [r.total_return for r in runs],
+            'sharpe_ratio': [r.sharpe_ratio for r in runs],
+            'max_drawdown': [r.max_drawdown for r in runs],
+            'total_trades': [r.total_trades for r in runs],
+            'win_rate': [r.win_rate for r in runs],
+        }
+        
+        return comparison
+    
+    def delete_run(self, run_id: str) -> bool:
+        """Delete a run from the registry."""
+        return self.store.delete_run(run_id)
+    
+    def get_best_runs(self, 
+                     metric: str = 'sharpe_ratio',
+                     n: int = 10,
+                     strategy_name: Optional[str] = None) -> List[RunRecord]:
+        """
+        Get top N runs by a metric.
+        
+        Args:
+            metric: Metric to sort by (sharpe_ratio, total_return, etc.)
+            n: Number of runs to return
+            strategy_name: Optional filter by strategy
+            
+        Returns:
+            List of top RunRecords
+        """
+        runs = self.list_runs(strategy_name=strategy_name)
+        
+        # Sort by metric
+        metric_key = {
+            'sharpe_ratio': lambda r: r.sharpe_ratio,
+            'total_return': lambda r: r.total_return,
+            'win_rate': lambda r: r.win_rate,
+            'total_trades': lambda r: r.total_trades,
+        }.get(metric, lambda r: r.sharpe_ratio)
+        
+        runs.sort(key=metric_key, reverse=True)
+        
+        return runs[:n]
+```
+
+### Phase 5: API Exports (`__init__.py`)
+
+```python
+"""Run Registry for tracking backtest runs."""
+
+from .run import RunRecord
+from .registry import RunRegistry
+from .store import RunStore
+from .stores.file_store import FileStore
+
+__all__ = [
+    'RunRecord',
+    'RunRegistry',
+    'RunStore',
+    'FileStore',
+]
+```
+
+---
+
+## 🚀 Usage Examples
+
+### Basic Usage
+
+```python
+import vectorbt as vbt
+from vectorbt.portfolio.registry import RunRegistry
+
+# Create registry (uses ./backtest_runs by default)
+registry = RunRegistry()
+
+# Run a backtest
+data = vbt.YFData.download("BTC-USD")
+price = data.get("Close")
+pf = vbt.Portfolio.from_holding(price, init_cash=100)
+
+# Save the run
+run_id = registry.save_run(
+    portfolio=pf,
+    strategy_name="buy_and_hold",
+    parameters={"symbol": "BTC-USD", "init_cash": 100},
+    tags=["crypto", "long-only"]
+)
+
+print(f"Saved run: {run_id}")
+```
+
+### List and Filter Runs
+
+```python
+# List all runs
+all_runs = registry.list_runs()
+for run in all_runs:
+    print(f"{run.strategy_name}: {run.total_return:.2f}% return")
+
+# Filter by strategy
+sma_runs = registry.list_runs(strategy_name="dual_sma")
+
+# Filter by tags
+crypto_runs = registry.list_runs(tags=["crypto"])
+```
+
+### Load and Compare
+
+```python
+# Load a specific run's portfolio
+pf = registry.load_portfolio(run_id)
+pf.plot().show()
+
+# Get best runs by Sharpe ratio
+top_runs = registry.get_best_runs(metric='sharpe_ratio', n=5)
+
+# Compare multiple runs
+comparison = registry.compare_runs([run_id1, run_id2, run_id3])
+import pandas as pd
+df = pd.DataFrame(comparison)
+print(df)
+```
+
+### Advanced: Parameter Sweep
+
+```python
+# Save results from a parameter sweep
+symbols = ["BTC-USD", "ETH-USD"]
+data = vbt.YFData.download(symbols)
+price = data.get("Close")
+
+for fast in [10, 20, 30]:
+    for slow in [50, 100, 200]:
+        if fast >= slow:
+            continue
+            
+        fast_ma = vbt.MA.run(price, fast)
+        slow_ma = vbt.MA.run(price, slow)
+        entries = fast_ma.ma_crossed_above(slow_ma)
+        exits = fast_ma.ma_crossed_below(slow_ma)
+        
+        pf = vbt.Portfolio.from_signals(price, entries, exits)
+        
+        registry.save_run(
+            portfolio=pf,
+            strategy_name="dual_sma",
+            parameters={"fast": fast, "slow": slow},
+            tags=["sma", "crossover"],
+            notes=f"Testing {fast}/{slow} windows"
+        )
+
+# Find best parameter combo
+best_runs = registry.get_best_runs(
+    strategy_name="dual_sma",
+    metric="sharpe_ratio",
+    n=3
+)
+
+for run in best_runs:
+    print(f"Fast: {run.parameters['fast']}, Slow: {run.parameters['slow']}")
+    print(f"Sharpe: {run.sharpe_ratio:.3f}")
+```
+
+---
+
+## 📁 Where Each File Goes
+
+```
+vectorbt/portfolio/registry/
+├── __init__.py                    # START HERE - exports
+├── run.py                         # RunRecord dataclass
+├── store.py                       # Abstract base (if needed)
+├── registry.py                    # RunRegistry main class
+└── stores/
+    ├── __init__.py
+    └── file_store.py              # FileStore implementation
+```
+
+Then update `vectorbt/portfolio/__init__.py` to include:
+
+```python
+from vectorbt.portfolio.registry import RunRegistry, RunRecord
+```
+
+---
+
+## 🎓 Why This Approach Works
+
+1. **Leverages Existing Infrastructure**
+   - Uses Portfolio's built-in `.save()` and `.load()`
+   - Follows vectorbt's existing patterns (Records, configs)
+
+2. **Loosely Coupled**
+   - Registry is independent of Portfolio internals
+   - Can add features without modifying core Portfolio
+
+3. **Extensible**
+   - Easy to add new storage backends (SQLite, cloud)
+   - Can add more metadata fields without breaking existing runs
+
+4. **Developer Friendly**
+   - Simple API matches vectorbt's style
+   - Minimal dependencies (just stdlib + existing vectorbt)
+
+---
+
+## 🛠️ Development Workflow
+
+1. **Create the folder structure** (15 min)
+2. **Implement `RunRecord` dataclass** (30 min)
+3. **Build `FileStore`** (1-2 hours)
+4. **Write `RunRegistry` interface** (1 hour)
+5. **Add tests** (1-2 hours)
+6. **Write documentation** (1 hour)
+7. **Create examples** (30 min)
+
+**Total estimated time: 6-8 hours of focused work**
+
+---
+
+## 📝 Next Steps for Patrick
+
+1. **Create the folder**: `mkdir -p vectorbt/portfolio/registry/stores`
+
+2. **Start with `run.py`**: Implement the RunRecord dataclass
+
+3. **Build `file_store.py`**: Start simple with JSON metadata + pickle portfolios
+
+4. **Create `registry.py`**: Implement the main API
+
+5. **Test manually**: Write a quick script to test save/load/list
+
+6. **Add unit tests**: Follow existing test patterns in `tests/`
+
+7. **Document**: Add docstrings and usage examples
+
+---
+
+## 🤝 Integration with vectorbt
+
+To make this feel native to vectorbt, consider adding a convenience method:
+
+```python
+# In vectorbt/portfolio/base.py
+class Portfolio(Pickleable, ...):
+    
+    def save_to_registry(self,
+                        strategy_name: str,
+                        parameters: dict = None,
+                        tags: list = None,
+                        notes: str = "",
+                        registry=None):
+        """Save this portfolio to the run registry."""
+        if registry is None:
+            from vectorbt.portfolio.registry import RunRegistry
+            registry = RunRegistry()
+        
+        return registry.save_run(
+            portfolio=self,
+            strategy_name=strategy_name,
+            parameters=parameters,
+            tags=tags,
+            notes=notes
+        )
+```
+
+Then users can simply:
+```python
+pf = vbt.Portfolio.from_signals(...)
+run_id = pf.save_to_registry(strategy_name="my_strategy")
+```
+
+---
+
+## 🎯 Summary
+
+**To answer your question:**
+- **Do you need a new folder?** → **YES**, create `vectorbt/portfolio/registry/`
+- **Is there baseline?** → **Partial** - serialization exists, but no registry yet
+- **Where to start?** → Begin with the `RunRecord` dataclass in `run.py`
+
+The good news: You're building something NEW that fills a real gap, and you have solid infrastructure to build on (serialization, records). This is a greenfield feature that will add significant value!
+
+Good luck! 🚀

--- a/vectorbt/tests/test_registry.py
+++ b/vectorbt/tests/test_registry.py
@@ -1,20 +1,134 @@
+import pytest
 from vectorbt.registry import Registry
 
-def test_registry_dedup(tmp_path):
-    reg = Registry(base_dir=str(tmp_path))
 
-    config = {
+@pytest.fixture
+def reg(tmp_path):
+    return Registry(base_dir=str(tmp_path))
+
+
+@pytest.fixture
+def base_config():
+    return {
         "data": {"source": "ccxt", "symbol": "BTC/USDT", "interval": "1h"},
         "date_range": {"start": "2024-01-01", "end": "2024-02-01"},
         "strategy": {"name": "buy_and_hold"},
         "execution": {"fees_bps": 10},
     }
 
-    e1 = reg.create(config, summary={"sharpe_ratio": 1.2, "total_return": 0.15})
-    e2 = reg.create(config, summary={"sharpe_ratio": 999})
+
+# ------------------------------------------------------------------ dedup
+
+def test_registry_dedup(reg, base_config):
+    e1 = reg.create(base_config, summary={"sharpe_ratio": 1.2, "total_return": 0.15})
+    e2 = reg.create(base_config, summary={"sharpe_ratio": 999})
 
     assert e1.run_id == e2.run_id
     assert len(reg.list()) == 1
 
     shown = reg.show(e1.run_id)
     assert set(shown.keys()) == {"run_id", "path", "config", "metrics", "versions"}
+
+
+# ------------------------------------------------------------------ delete
+
+def test_delete(reg, base_config):
+    entry = reg.create(base_config, summary={"sharpe_ratio": 1.2, "total_return": 0.15})
+    assert len(reg.list()) == 1
+
+    reg.delete(entry.run_id)
+    assert len(reg.list()) == 0
+
+
+def test_delete_nonexistent(reg):
+    with pytest.raises(FileNotFoundError):
+        reg.delete("nonexistent_run_id")
+
+
+# ------------------------------------------------------------------ compare
+
+def test_compare(reg, base_config):
+    config2 = {
+        **base_config,
+        "data": {**base_config["data"], "interval": "4h"},
+    }
+    e1 = reg.create(base_config, summary={"sharpe_ratio": 1.45, "total_return": 0.235, "max_drawdown": -0.123, "win_rate": 0.582})
+    e2 = reg.create(config2, summary={"sharpe_ratio": 1.12, "total_return": 0.182, "max_drawdown": -0.151, "win_rate": 0.521})
+
+    diff = reg.compare(e1.run_id, e2.run_id)
+
+    assert diff["run_id_1"] == e1.run_id
+    assert diff["run_id_2"] == e2.run_id
+    assert "rows" in diff
+
+    row_map = {r["field"]: r for r in diff["rows"]}
+    assert row_map["Interval"]["run1"] == "1h"
+    assert row_map["Interval"]["run2"] == "4h"
+    assert row_map["Interval"]["diff"] == "changed"
+
+    assert row_map["Symbol"]["diff"] == "-"
+
+    sharpe_diff = row_map["Sharpe Ratio"]["diff"]
+    assert abs(sharpe_diff - (1.12 - 1.45)) < 1e-4
+
+
+# ------------------------------------------------------------------ list filtering and sorting
+
+def test_list_filter_by_symbol(reg, base_config):
+    eth_config = {
+        **base_config,
+        "data": {**base_config["data"], "symbol": "ETH/USDT"},
+        "date_range": {"start": "2024-01-01", "end": "2024-02-01"},
+        "strategy": {"name": "buy_and_hold"},
+        "execution": {"fees_bps": 20},
+    }
+    reg.create(base_config, summary={"sharpe_ratio": 1.2, "total_return": 0.15})
+    reg.create(eth_config, summary={"sharpe_ratio": 0.9, "total_return": 0.10})
+
+    btc_runs = reg.list(filter_by="BTC")
+    eth_runs = reg.list(filter_by="ETH")
+
+    assert len(btc_runs) == 1
+    assert len(eth_runs) == 1
+    assert len(reg.list()) == 2
+
+
+def test_list_sort_by_sharpe(reg, base_config):
+    configs = [
+        ({**base_config, "execution": {"fees_bps": i}}, {"sharpe_ratio": v, "total_return": 0.1})
+        for i, v in enumerate([0.5, 1.8, 1.2])
+    ]
+    for cfg, summary in configs:
+        reg.create(cfg, summary=summary)
+
+    runs = reg.list(sort_by="sharpe")
+    sharpes = [r.summary.get("sharpe_ratio") for r in runs]
+    assert sharpes == sorted(sharpes, reverse=True)
+
+
+def test_list_sort_by_returns(reg, base_config):
+    configs = [
+        ({**base_config, "execution": {"fees_bps": i}}, {"sharpe_ratio": 1.0, "total_return": v})
+        for i, v in enumerate([0.05, 0.30, 0.15])
+    ]
+    for cfg, summary in configs:
+        reg.create(cfg, summary=summary)
+
+    runs = reg.list(sort_by="returns")
+    returns = [r.summary.get("total_return") for r in runs]
+    assert returns == sorted(returns, reverse=True)
+
+
+# ------------------------------------------------------------------ persistence
+
+def test_persistence(tmp_path, base_config):
+    reg1 = Registry(base_dir=str(tmp_path))
+    entry = reg1.create(base_config, summary={"sharpe_ratio": 1.5, "total_return": 0.20})
+
+    reg2 = Registry(base_dir=str(tmp_path))
+    runs = reg2.list()
+    assert len(runs) == 1
+    assert runs[0].run_id == entry.run_id
+
+    shown = reg2.show(entry.run_id)
+    assert shown["metrics"]["sharpe_ratio"] == 1.5

--- a/vectorbt/tests/test_registry.py
+++ b/vectorbt/tests/test_registry.py
@@ -1,0 +1,20 @@
+from vectorbt.registry import Registry
+
+def test_registry_dedup(tmp_path):
+    reg = Registry(base_dir=str(tmp_path))
+
+    config = {
+        "data": {"source": "ccxt", "symbol": "BTC/USDT", "interval": "1h"},
+        "date_range": {"start": "2024-01-01", "end": "2024-02-01"},
+        "strategy": {"name": "buy_and_hold"},
+        "execution": {"fees_bps": 10},
+    }
+
+    e1 = reg.create(config, summary={"sharpe_ratio": 1.2, "total_return": 0.15})
+    e2 = reg.create(config, summary={"sharpe_ratio": 999})
+
+    assert e1.run_id == e2.run_id
+    assert len(reg.list()) == 1
+
+    shown = reg.show(e1.run_id)
+    assert set(shown.keys()) == {"run_id", "path", "config", "metrics", "versions"}

--- a/vectorbt/vectorbt/registry/__init__.py
+++ b/vectorbt/vectorbt/registry/__init__.py
@@ -1,0 +1,3 @@
+from .registry import Registry
+
+__all__ = ["Registry"]

--- a/vectorbt/vectorbt/registry/__init__.py
+++ b/vectorbt/vectorbt/registry/__init__.py
@@ -1,3 +1,3 @@
-from .registry import Registry
+from vectorbt.registry.registry import Registry
 
 __all__ = ["Registry"]

--- a/vectorbt/vectorbt/registry/registry.py
+++ b/vectorbt/vectorbt/registry/registry.py
@@ -6,16 +6,41 @@ from .stores.file_store import FileStore, RunEntry
 
 
 class Registry:
-    """Public API for run registry."""
+    """Public API for the run registry."""
 
     def __init__(self, base_dir: str = "bt_runs"):
         self.store = FileStore(base_dir=base_dir)
 
-    def create(self, config: Dict[str, Any], summary: Optional[Dict[str, Any]] = None, force: bool = False) -> RunEntry:
+    def create(
+        self,
+        config: Dict[str, Any],
+        summary: Optional[Dict[str, Any]] = None,
+        force: bool = False,
+    ) -> RunEntry:
+        """Register a backtest run. Returns existing entry if config already seen (dedup)."""
         return self.store.create_run(config=config, summary=summary, force=force)
 
-    def list(self) -> List[RunEntry]:
-        return self.store.list()
+    def list(
+        self,
+        sort_by: Optional[str] = None,
+        filter_by: Optional[str] = None,
+    ) -> List[RunEntry]:
+        """List all runs.
+
+        Args:
+            sort_by: "date" (default), "sharpe", or "returns"
+            filter_by: Substring match on symbol or strategy name
+        """
+        return self.store.list(sort_by=sort_by, filter_by=filter_by)
 
     def show(self, run_id: str) -> Dict[str, Any]:
+        """Return full details for a run: config, metrics, versions."""
         return self.store.show(run_id)
+
+    def delete(self, run_id: str) -> None:
+        """Permanently remove a run from the registry and disk."""
+        self.store.delete_run(run_id)
+
+    def compare(self, run_id_1: str, run_id_2: str) -> Dict[str, Any]:
+        """Compare two runs side-by-side. Returns structured diff dict."""
+        return self.store.compare_runs(run_id_1, run_id_2)

--- a/vectorbt/vectorbt/registry/registry.py
+++ b/vectorbt/vectorbt/registry/registry.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .stores.file_store import FileStore, RunEntry
+
+
+class Registry:
+    """Public API for run registry."""
+
+    def __init__(self, base_dir: str = "bt_runs"):
+        self.store = FileStore(base_dir=base_dir)
+
+    def create(self, config: Dict[str, Any], summary: Optional[Dict[str, Any]] = None, force: bool = False) -> RunEntry:
+        return self.store.create_run(config=config, summary=summary, force=force)
+
+    def list(self) -> List[RunEntry]:
+        return self.store.list()
+
+    def show(self, run_id: str) -> Dict[str, Any]:
+        return self.store.show(run_id)

--- a/vectorbt/vectorbt/registry/run_id.py
+++ b/vectorbt/vectorbt/registry/run_id.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict
+
+
+def _canonicalize(obj: Any) -> Any:
+    """Convert config object into a deterministic, JSON-serializable form."""
+    if isinstance(obj, dict):
+        return {str(k): _canonicalize(obj[k]) for k in sorted(obj.keys(), key=str)}
+    if isinstance(obj, (list, tuple)):
+        return [_canonicalize(x) for x in obj]
+    # Basic JSON types are fine; everything else should be stringified
+    if obj is None or isinstance(obj, (str, int, float, bool)):
+        return obj
+    return str(obj)
+
+
+def canonical_config_json(config: Dict[str, Any]) -> str:
+    """Return canonical JSON string (stable ordering, no whitespace)."""
+    canonical = _canonicalize(config)
+    return json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def compute_run_id(config: Dict[str, Any]) -> str:
+    """Deterministic run id: sha256(canonical_config.json)."""
+    s = canonical_config_json(config)
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()

--- a/vectorbt/vectorbt/registry/stores/__init__.py
+++ b/vectorbt/vectorbt/registry/stores/__init__.py
@@ -1,0 +1,3 @@
+from .file_store import FileStore, RunEntry
+
+__all__ = ["FileStore", "RunEntry"]

--- a/vectorbt/vectorbt/registry/stores/__init__.py
+++ b/vectorbt/vectorbt/registry/stores/__init__.py
@@ -1,3 +1,0 @@
-from .file_store import FileStore, RunEntry
-
-__all__ = ["FileStore", "RunEntry"]

--- a/vectorbt/vectorbt/registry/stores/file_store.py
+++ b/vectorbt/vectorbt/registry/stores/file_store.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import dataclass
+import shutil
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -16,6 +17,7 @@ class RunEntry:
     timestamp: str
     path: str  # relative path, e.g. "runs/<run_id>"
     summary: Dict[str, Any]
+    strategy: str = ""  # strategy name or file path, for filtering
 
 
 class FileStore:
@@ -29,24 +31,21 @@ class FileStore:
             config.json
             versions.txt
             metrics.json
-            ... artifacts (later)
     """
 
-    def __init__(self, base_dir: str = "runs"):
+    def __init__(self, base_dir: str = "bt_runs"):
         self.base_dir = Path(base_dir)
         self.base_dir.mkdir(parents=True, exist_ok=True)
-
-        # NEW: keep all run folders inside base_dir/runs/
         self.runs_dir = self.base_dir / "runs"
         self.runs_dir.mkdir(parents=True, exist_ok=True)
-
-        # registry index stays at top level
         self.registry_path = self.base_dir / "registry.json"
+
+    # ------------------------------------------------------------------ helpers
 
     def _now_iso(self) -> str:
         return datetime.now(timezone.utc).isoformat()
 
-    def _atomic_write_json(self, path: Path, obj: Dict[str, Any]) -> None:
+    def _atomic_write_json(self, path: Path, obj: Any) -> None:
         tmp = path.with_suffix(path.suffix + ".tmp")
         tmp.write_text(json.dumps(obj, indent=2, ensure_ascii=False), encoding="utf-8")
         os.replace(tmp, path)
@@ -58,26 +57,17 @@ class FileStore:
 
     def _extract_index_fields(self, config: Dict[str, Any], summary: Dict[str, Any]) -> Dict[str, Any]:
         data = config.get("data", {}) if isinstance(config, dict) else {}
+        strategy = config.get("strategy", {}) if isinstance(config, dict) else {}
+        strategy_name = strategy.get("name") or strategy.get("file") or ""
         return {
             "symbol": data.get("symbol"),
             "interval": data.get("interval"),
+            "strategy": strategy_name,
             "total_return": summary.get("total_return"),
             "sharpe_ratio": summary.get("sharpe_ratio"),
         }
 
-    def list(self) -> List[RunEntry]:
-        reg = self._load_registry()
-        out: List[RunEntry] = []
-        for item in reg.get("runs", []):
-            out.append(
-                RunEntry(
-                    run_id=item["run_id"],
-                    timestamp=item["timestamp"],
-                    path=item["path"],
-                    summary=item.get("summary", {}),
-                )
-            )
-        return out
+    # ------------------------------------------------------------------ public
 
     def exists(self, run_id: str) -> bool:
         return (self.runs_dir / run_id).exists()
@@ -88,15 +78,12 @@ class FileStore:
         summary: Optional[Dict[str, Any]] = None,
         force: bool = False,
     ) -> RunEntry:
-        """Create run folder + update registry index."""
         summary = summary or {}
-
         run_id = compute_run_id(config)
         run_dir = self.runs_dir / run_id
         rel_path = f"runs/{run_id}"
 
         if run_dir.exists() and not force:
-            # Return existing entry if present in registry; else create minimal entry.
             for entry in self.list():
                 if entry.run_id == run_id:
                     return entry
@@ -106,25 +93,68 @@ class FileStore:
 
         run_dir.mkdir(parents=True, exist_ok=True)
 
-        # Write config.json (canonical)
         (run_dir / "config.json").write_text(canonical_config_json(config), encoding="utf-8")
 
-        # Write versions.txt (minimal, can expand later)
         versions_txt = f"created_at={self._now_iso()}\n"
         (run_dir / "versions.txt").write_text(versions_txt, encoding="utf-8")
 
-        # Write metrics.json (summary)
-        (run_dir / "metrics.json").write_text(
-            json.dumps(summary, indent=2, ensure_ascii=False),
-            encoding="utf-8",
-        )
+        self._atomic_write_json(run_dir / "metrics.json", summary)
 
-        entry = RunEntry(run_id=run_id, timestamp=self._now_iso(), path=rel_path, summary=summary)
+        fields = self._extract_index_fields(config, summary)
+        entry = RunEntry(
+            run_id=run_id,
+            timestamp=self._now_iso(),
+            path=rel_path,
+            summary=summary,
+            strategy=fields["strategy"] or "",
+        )
         self._append_registry(entry, config=config)
         return entry
 
+    def list(
+        self,
+        sort_by: Optional[str] = None,
+        filter_by: Optional[str] = None,
+    ) -> List[RunEntry]:
+        """Return all runs, with optional sorting and filtering.
+
+        Args:
+            sort_by: One of "date" (default), "sharpe", "returns"
+            filter_by: Substring to match against symbol or strategy name
+        """
+        reg = self._load_registry()
+        runs = reg.get("runs", [])
+
+        if filter_by:
+            q = filter_by.lower()
+            runs = [
+                r for r in runs
+                if q in (r.get("symbol") or "").lower()
+                or q in (r.get("strategy") or "").lower()
+            ]
+
+        entries = [
+            RunEntry(
+                run_id=r["run_id"],
+                timestamp=r["timestamp"],
+                path=r["path"],
+                summary=r.get("summary", {}),
+                strategy=r.get("strategy", ""),
+            )
+            for r in runs
+        ]
+
+        sort_key = sort_by or "date"
+        if sort_key == "sharpe":
+            entries.sort(key=lambda e: e.summary.get("sharpe_ratio") or float("-inf"), reverse=True)
+        elif sort_key == "returns":
+            entries.sort(key=lambda e: e.summary.get("total_return") or float("-inf"), reverse=True)
+        else:
+            entries.sort(key=lambda e: e.timestamp, reverse=True)
+
+        return entries
+
     def show(self, run_id: str) -> Dict[str, Any]:
-        """Load run details (config, metrics, versions) from disk."""
         run_dir = self.runs_dir / run_id
         if not run_dir.exists():
             raise FileNotFoundError(f"Run not found: {run_id}")
@@ -145,11 +175,79 @@ class FileStore:
             "versions": versions,
         }
 
+    def delete_run(self, run_id: str) -> None:
+        """Remove a run's folder and its entry from the registry index."""
+        run_dir = self.runs_dir / run_id
+        if not run_dir.exists():
+            raise FileNotFoundError(f"Run not found: {run_id}")
+
+        shutil.rmtree(run_dir)
+
+        reg = self._load_registry()
+        reg["runs"] = [r for r in reg.get("runs", []) if r.get("run_id") != run_id]
+        self._atomic_write_json(self.registry_path, reg)
+
+    def compare_runs(self, run_id_1: str, run_id_2: str) -> Dict[str, Any]:
+        """Return a structured diff of two runs' config and metrics."""
+        r1 = self.show(run_id_1)
+        r2 = self.show(run_id_2)
+
+        def _get(d: Dict, *keys: str):
+            for k in keys:
+                if isinstance(d, dict):
+                    d = d.get(k)
+                else:
+                    return None
+            return d
+
+        def _diff(v1, v2):
+            if v1 is None and v2 is None:
+                return None
+            if isinstance(v1, (int, float)) and isinstance(v2, (int, float)):
+                return round(v2 - v1, 6)
+            return "changed" if v1 != v2 else "-"
+
+        cfg_fields = [
+            ("Symbol",   ("config", "data", "symbol")),
+            ("Interval", ("config", "data", "interval")),
+            ("Start",    ("config", "data", "start")),
+            ("End",      ("config", "data", "end")),
+            ("Strategy", ("config", "strategy", "name")),
+            ("Exchange", ("config", "data", "exchange")),
+        ]
+
+        metric_fields = [
+            ("Total Return",  ("metrics", "total_return")),
+            ("Sharpe Ratio",  ("metrics", "sharpe_ratio")),
+            ("Max Drawdown",  ("metrics", "max_drawdown")),
+            ("Win Rate",      ("metrics", "win_rate")),
+            ("Total Trades",  ("metrics", "total_trades")),
+        ]
+
+        rows = []
+        for label, path in cfg_fields:
+            v1 = _get(r1, *path)
+            v2 = _get(r2, *path)
+            if v1 is not None or v2 is not None:
+                rows.append({"field": label, "run1": v1, "run2": v2, "diff": _diff(v1, v2)})
+
+        for label, path in metric_fields:
+            v1 = _get(r1, *path)
+            v2 = _get(r2, *path)
+            if v1 is not None or v2 is not None:
+                rows.append({"field": label, "run1": v1, "run2": v2, "diff": _diff(v1, v2)})
+
+        return {
+            "run_id_1": run_id_1,
+            "run_id_2": run_id_2,
+            "rows": rows,
+        }
+
+    # ------------------------------------------------------------------ private
+
     def _append_registry(self, entry: RunEntry, config: Dict[str, Any]) -> None:
         reg = self._load_registry()
         runs = reg.get("runs", [])
-
-        # de-dup by run_id
         runs = [r for r in runs if r.get("run_id") != entry.run_id]
 
         fields = self._extract_index_fields(config, entry.summary)
@@ -160,14 +258,14 @@ class FileStore:
                 "timestamp": entry.timestamp,
                 "symbol": fields["symbol"],
                 "interval": fields["interval"],
+                "strategy": fields["strategy"],
                 "total_return": fields["total_return"],
                 "sharpe_ratio": fields["sharpe_ratio"],
                 "path": entry.path,
-                "summary": entry.summary,  # keep full summary too
+                "summary": entry.summary,
             }
         )
 
-        # newest first
         runs.sort(key=lambda r: r["timestamp"], reverse=True)
         reg["runs"] = runs
         self._atomic_write_json(self.registry_path, reg)

--- a/vectorbt/vectorbt/registry/stores/file_store.py
+++ b/vectorbt/vectorbt/registry/stores/file_store.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ..run_id import canonical_config_json, compute_run_id
+
+
+@dataclass(frozen=True)
+class RunEntry:
+    run_id: str
+    timestamp: str
+    path: str  # relative path, e.g. "runs/<run_id>"
+    summary: Dict[str, Any]
+
+
+class FileStore:
+    """Filesystem-backed run registry.
+
+    Layout:
+      <base_dir>/
+        registry.json
+        runs/
+          <run_id>/
+            config.json
+            versions.txt
+            metrics.json
+            ... artifacts (later)
+    """
+
+    def __init__(self, base_dir: str = "runs"):
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+        # NEW: keep all run folders inside base_dir/runs/
+        self.runs_dir = self.base_dir / "runs"
+        self.runs_dir.mkdir(parents=True, exist_ok=True)
+
+        # registry index stays at top level
+        self.registry_path = self.base_dir / "registry.json"
+
+    def _now_iso(self) -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    def _atomic_write_json(self, path: Path, obj: Dict[str, Any]) -> None:
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(obj, indent=2, ensure_ascii=False), encoding="utf-8")
+        os.replace(tmp, path)
+
+    def _load_registry(self) -> Dict[str, Any]:
+        if not self.registry_path.exists():
+            return {"runs": []}
+        return json.loads(self.registry_path.read_text(encoding="utf-8"))
+
+    def _extract_index_fields(self, config: Dict[str, Any], summary: Dict[str, Any]) -> Dict[str, Any]:
+        data = config.get("data", {}) if isinstance(config, dict) else {}
+        return {
+            "symbol": data.get("symbol"),
+            "interval": data.get("interval"),
+            "total_return": summary.get("total_return"),
+            "sharpe_ratio": summary.get("sharpe_ratio"),
+        }
+
+    def list(self) -> List[RunEntry]:
+        reg = self._load_registry()
+        out: List[RunEntry] = []
+        for item in reg.get("runs", []):
+            out.append(
+                RunEntry(
+                    run_id=item["run_id"],
+                    timestamp=item["timestamp"],
+                    path=item["path"],
+                    summary=item.get("summary", {}),
+                )
+            )
+        return out
+
+    def exists(self, run_id: str) -> bool:
+        return (self.runs_dir / run_id).exists()
+
+    def create_run(
+        self,
+        config: Dict[str, Any],
+        summary: Optional[Dict[str, Any]] = None,
+        force: bool = False,
+    ) -> RunEntry:
+        """Create run folder + update registry index."""
+        summary = summary or {}
+
+        run_id = compute_run_id(config)
+        run_dir = self.runs_dir / run_id
+        rel_path = f"runs/{run_id}"
+
+        if run_dir.exists() and not force:
+            # Return existing entry if present in registry; else create minimal entry.
+            for entry in self.list():
+                if entry.run_id == run_id:
+                    return entry
+            entry = RunEntry(run_id=run_id, timestamp=self._now_iso(), path=rel_path, summary=summary)
+            self._append_registry(entry, config=config)
+            return entry
+
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        # Write config.json (canonical)
+        (run_dir / "config.json").write_text(canonical_config_json(config), encoding="utf-8")
+
+        # Write versions.txt (minimal, can expand later)
+        versions_txt = f"created_at={self._now_iso()}\n"
+        (run_dir / "versions.txt").write_text(versions_txt, encoding="utf-8")
+
+        # Write metrics.json (summary)
+        (run_dir / "metrics.json").write_text(
+            json.dumps(summary, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+        entry = RunEntry(run_id=run_id, timestamp=self._now_iso(), path=rel_path, summary=summary)
+        self._append_registry(entry, config=config)
+        return entry
+
+    def show(self, run_id: str) -> Dict[str, Any]:
+        """Load run details (config, metrics, versions) from disk."""
+        run_dir = self.runs_dir / run_id
+        if not run_dir.exists():
+            raise FileNotFoundError(f"Run not found: {run_id}")
+
+        config_path = run_dir / "config.json"
+        metrics_path = run_dir / "metrics.json"
+        versions_path = run_dir / "versions.txt"
+
+        config = json.loads(config_path.read_text(encoding="utf-8")) if config_path.exists() else {}
+        metrics = json.loads(metrics_path.read_text(encoding="utf-8")) if metrics_path.exists() else {}
+        versions = versions_path.read_text(encoding="utf-8") if versions_path.exists() else ""
+
+        return {
+            "run_id": run_id,
+            "path": f"runs/{run_id}",
+            "config": config,
+            "metrics": metrics,
+            "versions": versions,
+        }
+
+    def _append_registry(self, entry: RunEntry, config: Dict[str, Any]) -> None:
+        reg = self._load_registry()
+        runs = reg.get("runs", [])
+
+        # de-dup by run_id
+        runs = [r for r in runs if r.get("run_id") != entry.run_id]
+
+        fields = self._extract_index_fields(config, entry.summary)
+
+        runs.append(
+            {
+                "run_id": entry.run_id,
+                "timestamp": entry.timestamp,
+                "symbol": fields["symbol"],
+                "interval": fields["interval"],
+                "total_return": fields["total_return"],
+                "sharpe_ratio": fields["sharpe_ratio"],
+                "path": entry.path,
+                "summary": entry.summary,  # keep full summary too
+            }
+        )
+
+        # newest first
+        runs.sort(key=lambda r: r["timestamp"], reverse=True)
+        reg["runs"] = runs
+        self._atomic_write_json(self.registry_path, reg)


### PR DESCRIPTION
Completes the run registry implementation.

## What's added
- Registry.delete(run_id): remove a run from disk and index
- Registry.compare(run_id_1, run_id_2): side-by-side diff of config + metrics
- Registry.list(sort_by, filter_by): sort by date/sharpe/returns, filter by symbol or strategy
- Expanded tests: 8 tests covering all new methods and persistence

Closes #6
